### PR TITLE
Automatic scrolling

### DIFF
--- a/Console/Scripts/ConsoleGUI.cs
+++ b/Console/Scripts/ConsoleGUI.cs
@@ -10,6 +10,7 @@ public class ConsoleGUI : MonoBehaviour {
     private Rect consoleRect;
     private bool focus = false;
     private const int WINDOW_ID = 50;
+    private int scrollPosition;
 
     private void Start() {
         consoleRect = new Rect(0, 0, Screen.width, Mathf.Min(300, Screen.height));
@@ -32,7 +33,7 @@ public class ConsoleGUI : MonoBehaviour {
         HandleSubmit();
         HandleEscape();
 
-        GUILayout.BeginScrollView(Vector2.zero);
+        GUILayout.BeginScrollView(new Vector2(0, scrollPosition), false, true);
         GUILayout.Label(consoleLog.log);
         GUILayout.EndScrollView();
         GUI.SetNextControlName("input");

--- a/Console/Scripts/ConsoleLog.cs
+++ b/Console/Scripts/ConsoleLog.cs
@@ -13,8 +13,10 @@ public class ConsoleLog {
     }
 
     public string log = "";
+	public int scrollLength;
 
     public void Log(string message) {
         log += message + "\n";
+		scrollLength += 20;
     }
 }


### PR DESCRIPTION
For some reason, I doubt it was intended, the console would hit the bottom of the window and it wouldn't scroll with it. I fixed it by adding to a scrollPosition int that increments every time the Log function is called.
