### PR TITLE
Added default console command called listcommands to list any registered...

### DIFF
--- a/Console/Scripts/ConsoleCommandsRepository.cs
+++ b/Console/Scripts/ConsoleCommandsRepository.cs
@@ -18,10 +18,38 @@ public class ConsoleCommandsRepository {
   }
   public ConsoleCommandsRepository() {
     repository = new Dictionary<string, ConsoleCommandCallback>();
+    repository.Add ("listcommands", ListCommands);
+    ConsoleLog.Instance.Log ("Type 'listcommands' to get a list of console commands available");
+  }
+
+  public string ListCommands(params string[] args) {
+    var cmdList = string.Empty;
+    if (repository != null)
+    {
+      foreach (var kvp in repository)
+      {
+        if (kvp.Key.ToString() != "listcommands")
+        {
+          cmdList += kvp.Key.ToString() + System.Environment.NewLine;
+        }
+      }
+      return cmdList;
+    }
+    else
+    {
+      return "No commands have been setup. Use the RegisterCommand method on your console repository to add new commands.";
+    }
   }
 
   public void RegisterCommand(string command, ConsoleCommandCallback callback) {
-    repository[command] = new ConsoleCommandCallback(callback);
+    if (command == "listcommands")
+    {
+      throw new UnityException("You cannot register 'listcommands' as a command, as this is reserved for system use.");
+    }
+    else 
+    {
+      repository[command] = new ConsoleCommandCallback(callback);
+    }
   }
 
   public bool HasCommand(string command) {


### PR DESCRIPTION
... commands. Added message on creation of console to notify user of the “listcommands” ability. Basic handling to ensure users cannot register command called “listcommands” over the default.

Feel free to implement, improve on the idea, or reject :)
