### PR TITLE
Tab Command Completion and Command History

### DIFF
--- a/Console/Scripts/ConsoleCommandsRepository.cs
+++ b/Console/Scripts/ConsoleCommandsRepository.cs
@@ -28,6 +28,17 @@ public class ConsoleCommandsRepository {
     return repository.ContainsKey(command);
   }
 
+  public List<string> SearchCommands(string str) {
+		string[] keys = new string[repository.Count];
+		repository.Keys.CopyTo (keys, 0);
+		List<string> output = new List<string>();
+		foreach (string key in keys) {
+			if (key.StartsWith(str))
+				output.Add(key);
+		}
+		return output;
+  }
+
   public string ExecuteCommand(string command, string[] args) {
     if (HasCommand(command)) {
       return repository[command](args);

--- a/Console/Scripts/ConsoleGUI.cs
+++ b/Console/Scripts/ConsoleGUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 
 public class ConsoleGUI : MonoBehaviour {
     public ConsoleAction escapeAction;
@@ -10,11 +11,18 @@ public class ConsoleGUI : MonoBehaviour {
     private Rect consoleRect;
     private bool focus = false;
     private const int WINDOW_ID = 50;
+	private ConsoleCommandsRepository consoleCommandsRepository;
+
+	private int maxConsoleHistorySize = 100;
+	private int consoleHistoryPosition = 0;
+	private List<string> consoleHistoryCommands = new List<string>();
+	private bool fixPositionNextFrame = false; // a hack because the up arrow moves the cursor to the first position.
 
     private void Start() {
         consoleRect = new Rect(0, 0, Screen.width, Mathf.Min(300, Screen.height));
         consoleLog = ConsoleLog.Instance;
-    }
+		consoleCommandsRepository = ConsoleCommandsRepository.Instance;
+	}
 
     private void OnEnable() {
         focus = true;
@@ -29,8 +37,16 @@ public class ConsoleGUI : MonoBehaviour {
     }
 
     private void RenderWindow(int id) {
+		if (fixPositionNextFrame) 
+		{
+			MoveCursorToPos (input.Length);
+			fixPositionNextFrame = false;
+		}
         HandleSubmit();
         HandleEscape();
+		HandleTab();
+		HandleUp ();
+		HandleDown ();
 
         GUILayout.BeginScrollView(Vector2.zero);
         GUILayout.Label(consoleLog.log);
@@ -43,10 +59,85 @@ public class ConsoleGUI : MonoBehaviour {
         }
     }
 
+	private string LargestSubString(string in1, string in2) // takes two strings and returns the largest matching substring.
+	{
+		string output = "";
+		int smallestLen = Mathf.Min(in1.Length, in2.Length);
+		for (int i = 0; i<smallestLen; i++) {
+			if (in1[i] == in2[i]) output += in1[i];
+			else return output;
+			}
+		return output;
+	}
+
+	private void MoveCursorToPos(int position)
+	{
+		TextEditor editor = (TextEditor)GUIUtility.GetStateObject(typeof(TextEditor), GUIUtility.keyboardControl);
+		editor.selectPos = position;
+		editor.pos = position;
+		return;
+	}
+
+	private void HandleTab() 
+	{
+		if (KeyDown ("tab")) {
+			if (input != "") { // don't do anything if the input field is still blank.
+				List<string> search = consoleCommandsRepository.SearchCommands (input);
+				if (search.Count == 0) { // nothing found
+					consoleLog.Log ("No command start with \"" + input + "\".");
+					input = ""; // clear input
+					return;
+				} else if (search.Count == 1) {
+					input = search[0] + " "; // only found one command - type it in for the guy
+					MoveCursorToPos(input.Length);
+				} else {
+					consoleLog.Log ("Commands starting with \"" + input + "\":");
+					string largestMatch = search[0]; // keep track of the largest substring that matches all searches
+					foreach (string command in search)
+					{
+						consoleLog.Log (command);
+						largestMatch = LargestSubString(largestMatch, command);
+					}
+					input = largestMatch;
+					MoveCursorToPos(input.Length);
+				}
+			}
+		}
+	}
+
+	private void HandleUp()
+	{
+		if (KeyDown ("up")) {
+			consoleHistoryPosition += 1;
+			if (consoleHistoryPosition > consoleHistoryCommands.Count - 1) consoleHistoryPosition = consoleHistoryCommands.Count - 1;
+			input = consoleHistoryCommands[consoleHistoryPosition];
+			fixPositionNextFrame = true; 
+			//MoveCursorToPos(input.Length);
+		}
+	}
+
+	private void HandleDown()
+	{
+		if (KeyDown ("down")) {
+			consoleHistoryPosition -= 1;
+			if (consoleHistoryPosition < 0) {
+				consoleHistoryPosition = -1;
+				input = "";
+			}
+			else
+				input = consoleHistoryCommands[consoleHistoryPosition];
+			MoveCursorToPos(input.Length);
+		}
+	}
+
     private void HandleSubmit() {
         if (KeyDown("[enter]") || KeyDown("return")) {
-            if (submitAction != null) {
+			consoleHistoryPosition = -1; // up arrow or down arrow will set it to 0, which is the last command typed.
+			if (submitAction != null) {
                 submitAction.Activate();
+				consoleHistoryCommands.Insert(0, input);
+				if (consoleHistoryCommands.Count > maxConsoleHistorySize)
+					consoleHistoryCommands.RemoveAt(consoleHistoryCommands.Count-1);
             }
             input = "";
         }
@@ -58,6 +149,11 @@ public class ConsoleGUI : MonoBehaviour {
             input = "";
         }
     }
+
+	private void Update() {
+		if (input == "`")
+			input = "";
+	}
 
     private bool KeyDown(string key) {
         return Event.current.Equals(Event.KeyboardEvent(key));


### PR DESCRIPTION
Type the beginning characters of a command, hit tab, and see the list of
possible commands starting with that (intelligently autocompletes to
match the smallest substring that all commands begin with).  If only one
possible command exists, it types that command and a space.

When commands are entered, they are added to a list of historic entries,
which can be called up by hitting up/down arrows.

Also, fixed the bug where the backtick character would show up in the
console when it was opening sometimes.  Might be a better way to
implement that though.  Just delete the Update function if you don't want that, and everything else is fine.
